### PR TITLE
Make macOS app Retina display-capable

### DIFF
--- a/pkg/macOS/Contents/Info.plist
+++ b/pkg/macOS/Contents/Info.plist
@@ -24,5 +24,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
By default on macOS, the Geode Installer looks like garbage because it doesn't take advantage of the high resolution display. In the Info.plist, a key can be set called `NSHighResolutionCapable` that will pretty much fix this.


Before:
![  2022-07-04 at 17 22 37](https://user-images.githubusercontent.com/87151697/177217799-c2b03dba-cec1-4ad2-8659-2b3c8cc39669.png)

After:
<img width="552" alt="  2022-07-04 at 17 22 46" src="https://user-images.githubusercontent.com/87151697/177217807-3f72713d-5f66-4421-a161-d44e3f3b57c6.png">